### PR TITLE
Add RHEL support

### DIFF
--- a/Vulmap-Linux/vulmap-linux.py
+++ b/Vulmap-Linux/vulmap-linux.py
@@ -77,7 +77,7 @@ def sendRequest(queryData):
 
 		else:
 			request = urllib2.Request(url, body, headers)
-			result = urllib2.urlopen(request, timeout=5)
+			result = urllib2.urlopen(request, timeout=240)
 			response = json.loads(result.read())
 	else:
 		if args.proxy:


### PR DESCRIPTION
This pull request resolves issue #16 and allows the Vulmap Linux script to work on RHEL based systems that utilize `rpm` package manager. 

The following changes have been done:

- Increase the timeout to 240 seconds since Vulnmon API is responding slower.
- Added a function for extracting base distro type.
- Added `rpm` command in the same format as `dpkg` in the getProductList().

The remaining flow of the script has not been modified.
Other package managers  can be added in the same way based on a different distro if they follow `/etc/os-release` convention.