### PR TITLE
Update vulmap-windows.ps1

### DIFF
--- a/Vulmap-Windows/vulmap-windows.ps1
+++ b/Vulmap-Windows/vulmap-windows.ps1
@@ -158,7 +158,7 @@
                     ForEach ($key in $subkeys) {
                         $DisplayName = $key.getValue('DisplayName')
 
-                        if ($null -notlike $DisplayName) {
+                        if ($null -ne $DisplayName) {
                             $DisplayVersion = $key.GetValue('DisplayVersion')
 
                             [PSCustomObject]@{


### PR DESCRIPTION
Use `-ne` instead of `-notlike` to avoid issues with certain application DisplayNames.

**Example of issue with `-notlike`:**
```
PS C:\Users\wise-io> $DisplayName = "Test Application [Fail-Me]"
PS C:\Users\wise-io> if ($null -notlike $DisplayName) { Write-Output 'Yay' }
The specified wildcard character pattern is not valid: Test Application [Fail-Me]
At line:1 char:5
+ if ($null -notlike $DisplayName) { Write-Output 'No error' }
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], WildcardPatternException
    + FullyQualifiedErrorId : RuntimeException
```
